### PR TITLE
Fixed tasks that were previously renamed.

### DIFF
--- a/.settings/tasks.json
+++ b/.settings/tasks.json
@@ -20,13 +20,13 @@
                 "$jshint"
             ]
         },{
-            "taskName": "ts-compile",
+            "taskName": "tsc",
             "problemMatcher": "$tsc"
         },{
-            "taskName": "ts-compile-client",
+            "taskName": "tsc-client",
             "problemMatcher": "$tsc"
         },{
-            "taskName": "ts-compile-server",
+            "taskName": "tsc-server",
             "problemMatcher": "$tsc"
         },{
             "taskName": "test",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,11 +53,11 @@ gulp.task('default', ['help']);
 gulp.task('ts-watcher', ['ts-watcher-client', 'ts-watcher-server']);
 
 gulp.task('ts-watcher-client', function() {
-    gulp.watch(config.ts.clientts, ['ts-compile-client']);
+    gulp.watch(config.ts.clientts, ['tsc-client']);
 });
 
 gulp.task('ts-watcher-server', function() {
-    gulp.watch(config.ts.serverts, ['ts-compile-server']);
+    gulp.watch(config.ts.serverts, ['tsc-server']);
 });
 
 /**


### PR DESCRIPTION
It appears that in an earlier commit you renamed from ts-compile to tsc- but did not rename the watchers.